### PR TITLE
Fix perms

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -35,11 +35,11 @@ case "${1}" in
   install)
     [ "$(id -u)" -ne 0 ] && error_msg "${1} as root"
     for file in "${toplevel}"/usr/bin/*; do
-      [ -f "${file}" ] && cp "${file}" /usr/bin/
+      [ -f "${file}" ] && install "${file}" /usr/bin/
     done
     for mandir in "/usr/local/man/man8" "/usr/local/share/man/man8" "/usr/share/man/man8"; do
       manual="${toplevel}/auto-generated-man-pages/${script_name}.8"
-      [ -d "${mandir}" ] && [ -f "${manual}" ] && cp "${manual}" "${mandir}" && break
+      [ -d "${mandir}" ] && [ -f "${manual}" ] && install "${manual}" "${mandir}" && break
     done
   ;;
 


### PR DESCRIPTION
I usually run my user with `umask 0077`, so if the tor-ctrl repo is checked out without the group/other bits set, then by default `cp` will not set the read and execute bits correctly.

This changes the `cp` to `install`, which sets the bits correctly.